### PR TITLE
Stable log test.

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -20,7 +20,3 @@ echo == Test service.
 echo
 
 dfx canister call Main selfTest
-LOOP="(true)";
-while [ "$LOOP" == "(true)" ]; do
-    LOOP=$(dfx canister call Main doNextCall)
-done

--- a/test/Main.mo
+++ b/test/Main.mo
@@ -21,25 +21,36 @@ actor {
 
   let append = Sequence.defaultAppend();
 
-  public type Event = { // to do -- use this more realistically
-    #foo;
-    #bar;
+  /// Event type to illustrate "event log" design pattern, perhaps silly here.
+  public type Event = {
+    #build;
+    #sum;
+    #min;
+    #max;
+    #equalIter;
+    #bisimulationTest;
+    #testPop;
+    #testSlice;
+    #testSort;
+    #testTokens;
     #selfTest;
-    #doNextCall;
   };
 
+  /// Event log type to illustrate "event log" design pattern.
   public type EventLog = Sequence<Event>;
 
+  /// Event log design pattern.
   stable var eventLog : EventLog = Sequence.empty();
   stable var eventCount : Nat = 0;
 
-  /// log the given event kind, with a unique ID and current time
+  /// log the given event kind.
   func logEvent(e : Event) {
     eventLog := append<Event>(eventLog, Sequence.make(e));
     eventCount += 1;
   };
 
   func build<X>(arr : [X]) : (Sequence<X>, Buffer<X>) {
+    logEvent(#build);
     let b = Buffer.Buffer<X>(0);
     for (x in arr.vals()) {
       b.add(x);
@@ -50,10 +61,12 @@ actor {
   };
 
   func sum(x : Sequence<Nat>) : Nat {
+    logEvent(#sum);
     Sequence.binaryOp(x, 0, Nat.add);
   };
 
   func min(x : Sequence<Nat>) : Nat {
+    logEvent(#min);
     Sequence.binaryOp(x, 0, Nat.min);
   };
 
@@ -63,6 +76,7 @@ actor {
   ///
   /// E.g., Consider `?Nat` to be encoding `Nat` with special element (`null`), representing "bottom".
   func max(x : Sequence<?Nat>) : ?Nat {
+    logEvent(#max);
     Sequence.monoid(
       x,
       null,
@@ -79,6 +93,7 @@ actor {
 
   func equalIter<X>(i : Iter.Iter<X>, j : Iter.Iter<X>,
                     text : X -> Text, equal : (X, X) -> Bool) : Bool {
+    logEvent(#equalIter);
     Debug.print "test equality:";
     loop {
       let (x, y) = (i.next(), j.next());
@@ -114,6 +129,7 @@ actor {
   };
 
   func bisimulationTest(x : Sequence<Nat>, y : Buffer<Nat>) {
+    logEvent(#bisimulationTest);
     assert equal(x, y);
 
     Debug.print "sequence append";
@@ -134,6 +150,7 @@ actor {
   };
 
   func testPop() {
+    logEvent(#testPop);
     Debug.print "sequence popFront";
     let first = 10;
     let last = 11;
@@ -150,6 +167,7 @@ actor {
   };
 
   func testSlice() {
+    logEvent(#testSlice);
     Debug.print "sequence slice";
     let (s, _) = build<Nat>([1, 2, 3, 4, 5, 6, 7, 8,
                         9, 10, 11, 12, 13, 14, 15, 16]);
@@ -159,6 +177,7 @@ actor {
   };
 
   func testSort() {
+    logEvent(#testSort);
     Debug.print "sequence sort";
     let (s, _) = build<Nat>([10, 4, 2, 0, 1, 8, 0, 2, 3, 1, 0, 2]);
     let (_, b) = build<Nat>([0, 0, 0, 1, 1, 2, 2, 2, 3, 4, 8, 10]);
@@ -167,6 +186,7 @@ actor {
   };
 
   func testTokens() {
+    logEvent(#testTokens);
     Debug.print "sequence tokens";
     let (s1, _) = build<Text>(["A", " ", "c", "a", "t", " ", "a", "n", "d", " ", "h", "a", "t", "."]);
     let (s2, _) = build<Text>(["A", "cat", "and", "hat."]);
@@ -193,8 +213,4 @@ actor {
     Debug.print "SUCCESS";
   };
 
-  public func doNextCall() : async Bool {
-    logEvent(#doNextCall);
-    false
-  };
 }

--- a/test/Main.mo
+++ b/test/Main.mo
@@ -21,6 +21,24 @@ actor {
 
   let append = Sequence.defaultAppend();
 
+  public type Event = { // to do -- use this more realistically
+    #foo;
+    #bar;
+    #selfTest;
+    #doNextCall;
+  };
+
+  public type EventLog = Sequence<Event>;
+
+  stable var eventLog : EventLog = Sequence.empty();
+  stable var eventCount : Nat = 0;
+
+  /// log the given event kind, with a unique ID and current time
+  func logEvent(e : Event) {
+    eventLog := append<Event>(eventLog, Sequence.make(e));
+    eventCount += 1;
+  };
+
   func build<X>(arr : [X]) : (Sequence<X>, Buffer<X>) {
     let b = Buffer.Buffer<X>(0);
     for (x in arr.vals()) {
@@ -163,6 +181,7 @@ actor {
   };
 
   public func selfTest() {
+    logEvent(#selfTest);
     Debug.print "BEGIN bi-simulation of Sequence versus Buffer modules";
     let (s0, b0) = build<Nat>([1, 2, 3, 4, 5, 6, 7, 8,
                           9, 10, 11, 12, 13, 14, 15, 16]);
@@ -175,6 +194,7 @@ actor {
   };
 
   public func doNextCall() : async Bool {
+    logEvent(#doNextCall);
     false
   };
 }


### PR DESCRIPTION
Test an idea about stable memory design.

The key idea is to use a "lossless" canister event log, as a sequence that grows monotonically, as the format for stable memory, upgrades, and recoveries from upgrade failures or other bug-related investigations.

This PR begins to experiment with that idea, in baby steps.

This PR shows 
 - that the sequence can serve as an event log with minimal extra helper code.
 - that the sequence type is `shared`, and thus admissible to type the `stable var` for the `eventLog`.
 
 Subsequent PRs can demonstrate how the event log persists across upgrades.